### PR TITLE
Changes to Styleguide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # Styleguide
+We are using a modified version of the Google Styleguide and the 
+<a href="https://marketplace.visualstudio.com/items?itemName=shengchen.vscode-checkstyle">
+Checkstyle for Java</a> extension to lint our Java files.
+
+## Usage
+1. Install the <a href="https://marketplace.visualstudio.com/items?itemName=shengchen.vscode-checkstyle">
+Checkstyle for Java</a> extension and add styleguide-frc4607.xml to the project directory
+2. Add/modify the following in .vscode/settings.json
+
+```json
+"[java]": {
+    "editor.tabSize": 4,
+    "editor.detectIndentation": false,
+    "editor.insertSpaces": true
+},
+"editor.formatOnSave": false,
+"java.checkstyle.configuration": "${workspaceFolder}/google_checks.xml",
+"java.checkstyle.version": "10.3",
+```
+3. (Optional) Add the 
+<a href="https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker">
+Code Spell Checker</a> extension.
+
+## About
+This linting is based off of the <a href="https://google.github.io/styleguide/javaguide.html">Google Style Guide</a>
+modified to our liking.

--- a/styleguide-frc4607.xml
+++ b/styleguide-frc4607.xml
@@ -314,7 +314,9 @@
       <property name="forbiddenSummaryFragments"
                value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
     </module>
-    <module name="JavadocParagraph"/>
+    <module name="JavadocParagraph">
+      <property name="allowNewlineParagraph" value="false"/>
+    </module>
     <module name="RequireEmptyLineBeforeBlockTagGroup"/>
     <module name="AtclauseOrder">
       <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>

--- a/styleguide-frc4607.xml
+++ b/styleguide-frc4607.xml
@@ -39,7 +39,7 @@
 
   <module name="LineLength">
     <property name="fileExtensions" value="java"/>
-    <property name="max" value="100"/>
+    <property name="max" value="125"/>
     <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
   </module>
 

--- a/styleguide-frc4607.xml
+++ b/styleguide-frc4607.xml
@@ -255,7 +255,7 @@
     </module>
     <module name="AbbreviationAsWordInName">
       <property name="ignoreFinal" value="false"/>
-      <property name="allowedAbbreviationLength" value="0"/>
+      <property name="allowedAbbreviationLength" value="5"/>
       <property name="tokens"
                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
                     PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,


### PR DESCRIPTION
Added Documentation
Added the ability to have abbreviations with a max length of 5 characters
Added changes that prevent the default formater from conflicting with the styleguide including:
   - Increased line length
   - Allowed the text in Javadocs to be separated from the `<p>` tag on a new line